### PR TITLE
Refactor: Replace ManyToMany with event-assistants entity between userInformation and Events entities

### DIFF
--- a/back/src/events/entity/event-assistants.entity.ts
+++ b/back/src/events/entity/event-assistants.entity.ts
@@ -1,0 +1,27 @@
+import { status } from 'src/common/enum/status.enum';
+import { UserInformation } from 'src/user-information/entities/user-information.entity';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Event } from './events.entity';
+
+@Entity({ name: 'event_assistants' })
+export class EventAssistants {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'enum', enum: status, default: status.ACTIVE })
+  status: status;
+
+  @ManyToOne(() => UserInformation, (userInformation) => userInformation.assistantEvents)
+  @JoinColumn()
+  user: UserInformation;
+
+  @ManyToOne(() => Event, (event) => event.assistants)
+  @JoinColumn()
+  event: Event;
+}

--- a/back/src/events/entity/events.entity.ts
+++ b/back/src/events/entity/events.entity.ts
@@ -11,6 +11,7 @@ import {
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { EventAssistants } from './event-assistants.entity';
 
 @Entity({
   name: 'event',
@@ -56,10 +57,12 @@ export class Event {
   @OneToMany(() => Comment, (comment) => comment.event)
   comments: Comment[];
 
-  @ManyToMany(
-    () => UserInformation,
-    (userInformation) => userInformation.assistantEvents,
-  )
-  @JoinColumn()
-  assistants: UserInformation[];
+  @OneToMany(() => EventAssistants, (eventAssistants) => eventAssistants.event)
+  assistants: EventAssistants[];
+
+  // @ManyToMany(
+  //   () => UserInformation,
+  //   (userInformation) => userInformation.assistantEvents,
+  // )
+  // assistants: UserInformation[];
 }

--- a/back/src/user-information/entities/user-information.entity.ts
+++ b/back/src/user-information/entities/user-information.entity.ts
@@ -1,5 +1,6 @@
 import { Comment } from 'src/comments/entities/comments.entity';
 import { Donation } from 'src/donations/entities/donation.entity';
+import { EventAssistants } from 'src/events/entity/event-assistants.entity';
 import { Event } from 'src/events/entity/events.entity';
 import { File } from 'src/files/entities/file.entity';
 import { Order } from 'src/orders/entities/order.entity';
@@ -10,6 +11,7 @@ import { Product } from 'src/products/entity/products.entity';
 import { User } from 'src/users/entities/user.entity';
 import {
   Entity,
+  JoinColumn,
   JoinTable,
   ManyToMany,
   OneToMany,
@@ -55,7 +57,10 @@ export class UserInformation {
   @ManyToMany(() => File, (file) => file.creator)
   files: File[];
 
-  @ManyToMany(() => Event, (event) => event.assistants)
-  @JoinTable()
-  assistantEvents: Event[];
+  @OneToMany(() => EventAssistants, (eventAssistants) => eventAssistants.user)
+  assistantEvents: EventAssistants[];
+
+  // @ManyToMany(() => Event, (event) => event.assistants)
+  // @JoinTable()
+  // assistantEvents: Event[];
 }


### PR DESCRIPTION
This pull request adds a new entity event-assistants.entity.ts, which replaces the previous join table in the ManyToMany relationship between userInformation and Events entities.

Changes:
Replaced the ManyToMany connection with OneToMany/ManyToOne using the new event-assistants entity.
Refactored the respective properties in both entities to accommodate the change.