### PR TITLE
Added POST route `updateattendance/:id`  and implements logic to record assitants and stock

### DIFF
--- a/back/src/events/entity/event-assistants.entity.ts
+++ b/back/src/events/entity/event-assistants.entity.ts
@@ -17,14 +17,14 @@ export class EventAssistants {
   @Column({ type: 'enum', enum: status, default: status.ACTIVE })
   status: status;
 
-  @ManyToOne(
-    () => UserInformation,
-    (userInformation) => userInformation.assistantEvents,
-  )
+  @Column({ type: 'uuid', nullable: false })
+  eventId: string;
+
+  @ManyToOne(() => UserInformation, (userInformation) => userInformation.assistantEvents)
   @JoinColumn()
   user: UserInformation;
 
   @ManyToOne(() => Event, (event) => event.assistants)
   @JoinColumn()
-  event: Event;
+  event: Event;  
 }

--- a/back/src/events/entity/events.entity.ts
+++ b/back/src/events/entity/events.entity.ts
@@ -1,12 +1,10 @@
 import { Comment } from 'src/comments/entities/comments.entity';
 import { status } from 'src/common/enum/status.enum';
-import { OrderDetail } from 'src/order-details/entities/order-detail.entity';
 import { UserInformation } from 'src/user-information/entities/user-information.entity';
 import {
   Column,
   Entity,
   JoinColumn,
-  ManyToMany,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -59,10 +57,4 @@ export class Event {
 
   @OneToMany(() => EventAssistants, (eventAssistants) => eventAssistants.event)
   assistants: EventAssistants[];
-
-  // @ManyToMany(
-  //   () => UserInformation,
-  //   (userInformation) => userInformation.assistantEvents,
-  // )
-  // assistants: UserInformation[];
 }

--- a/back/src/events/event-assistants.repository.ts
+++ b/back/src/events/event-assistants.repository.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@nestjs/common";
+import { DataSource, Repository } from "typeorm";
+import { EventAssistants } from "./entity/event-assistants.entity";
+
+@Injectable()
+export class EventAssistantsRepository extends Repository<EventAssistants> {
+    constructor(private readonly dSource: DataSource) {
+        super(EventAssistants, dSource.getRepository(EventAssistants).manager);
+    }
+
+    async createEventAssistants(params) {
+        const newEventAttendant = await this.create({ user: { id: params.userId}});
+        const savedEventAttendant = await this.save(newEventAttendant);
+        console.log('Gamma => EventAssistantsRepository, createEventAssistants, savedEventAttendant', savedEventAttendant);
+        return savedEventAttendant;
+    }
+}

--- a/back/src/events/events.controller.ts
+++ b/back/src/events/events.controller.ts
@@ -5,23 +5,19 @@ import {
   Body,
   Patch,
   Param,
-  Delete,
   Query,
   HttpException,
   UsePipes,
-  ParseUUIDPipe,
-  UseGuards,
   UseInterceptors,
+  BadRequestException,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { EventsService } from './events.service';
 import { CreateEventDto } from './dto/create-event.dto';
 import { UpdateEventDto } from './dto/update-event.dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { DTOValidationPipe } from 'src/common/pipes/DTO-Validation.pipe';
-import { UUID } from 'crypto';
 import { IsUUIDPipe } from 'src/common/pipes/isUUID.pipe';
-import { ExistingEventGuard } from 'src/security/guards/existing-event.guard';
-import { EventsRepository } from './events.repository';
 import { ParseEventDataInterceptor } from 'src/security/interceptors/parse-event-data.interceptor';
 
 @ApiTags('Events')
@@ -29,7 +25,6 @@ import { ParseEventDataInterceptor } from 'src/security/interceptors/parse-event
 export class EventsController {
   constructor(
     private readonly eventsService: EventsService,
-    private readonly eventRepo: EventsRepository,
   ) {}
 
   @Post()
@@ -71,10 +66,19 @@ export class EventsController {
     return eventResponse;
   }
 
-  @Get('getone')
+  @Get('getone/:id')
   @ApiOperation({ summary: 'Ruta para la obtención de un evento por su ID' })
   async findOne(@Query('id') id: string) {
     return await this.eventsService.findOne(id);
+  }
+
+  @Post('updateattendance/:id')
+  async updateAttendanceStatus(@Param('id', ParseUUIDPipe) id: string, @Body() user: any) {
+    try {
+      return await this.eventsService.updateAttendanceStatus({eventId: id, ...user});
+    } catch (error) {
+      throw new BadRequestException(error.message);
+    }
   }
 
   @Patch('highlight/:id')

--- a/back/src/events/events.module.ts
+++ b/back/src/events/events.module.ts
@@ -4,10 +4,14 @@ import { EventsController } from './events.controller';
 import { EventsRepository } from './events.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Event } from './entity/events.entity';
+import { UserInformationRepository } from 'src/user-information/user-information.repository';
+import { MailerService } from 'src/mailer/mailer.service';
+import { EventAssistantsRepository } from './event-assistants.repository';
+import { EventAssistants } from './entity/event-assistants.entity';
 
 @Module({
   controllers: [EventsController],
-  providers: [EventsService, EventsRepository],
-  imports: [TypeOrmModule.forFeature([Event])],
+  providers: [EventsService, EventsRepository, UserInformationRepository, EventAssistantsRepository, MailerService],
+  imports: [TypeOrmModule.forFeature([Event, EventAssistants])],
 })
 export class EventsModule {}

--- a/back/src/events/events.service.ts
+++ b/back/src/events/events.service.ts
@@ -1,12 +1,20 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { UpdateEventDto } from './dto/update-event.dto';
 import { EventsRepository } from './events.repository';
-import { response } from 'express';
 import { Event } from './entity/events.entity';
+import { UserInformationRepository } from 'src/user-information/user-information.repository';
+import { MailerService } from 'src/mailer/mailer.service';
+import { EventAssistantsRepository } from './event-assistants.repository';
+import { status } from 'src/common/enum/status.enum';
 
 @Injectable()
 export class EventsService {
-  constructor(private readonly eventRepo: EventsRepository) {}
+  constructor(
+    private readonly eventRepo: EventsRepository,
+    private readonly userInfoRepo: UserInformationRepository,
+    private readonly eventAssistantsRepo: EventAssistantsRepository,
+    private readonly mailerService: MailerService
+  ) {}
 
   async create(eventData) {
     const createdEvent = this.eventRepo.create(eventData);
@@ -65,6 +73,43 @@ export class EventsService {
       throw new BadRequestException(`Event with id:${id} not found`);
     }
     return event;
+  }
+
+  async updateAttendanceStatus(param) {
+    const event = await this.eventRepo.findOne({
+      where: { id: param.eventId },
+      relations: { assistants: true }
+    });
+    if (!event) throw new BadRequestException(`User or Event not found`)
+    if (event.stock !== 0) {
+      const assistantsActive = event.assistants.filter(assistant => assistant.status === status.ACTIVE)
+      if (assistantsActive.length >= event.stock) throw new BadRequestException(`Event with id:${param.eventId} is full`)
+    }
+    const user = await this.userInfoRepo.findOne({
+      where: { id: param.creator },
+      relations: { user: true }
+    });
+    if (!user) throw new BadRequestException(`User or Event not found`)
+    const attendance = await this.eventAssistantsRepo.findOne({
+      where: { user: { id: user.id }, event: { id: event.id } }
+    })
+    if (!attendance) {
+      const newEventAttendant = await this.eventAssistantsRepo.create({
+        user,
+        event,
+        eventId: param.eventId,
+        status: status.ACTIVE
+      })
+      await this.eventAssistantsRepo.save(newEventAttendant);
+    } else if (attendance.status === status.ACTIVE) {
+      await this.eventAssistantsRepo.update(attendance.id, { status: status.INACTIVE });
+
+    } else {
+      await this.eventAssistantsRepo.update(attendance.id, { status: status.ACTIVE });
+    }
+    const updatedEvent = await this.eventRepo.findOne({ where: { id: param.eventId }, relations: { assistants: true } })
+    const updateUser = await this.userInfoRepo.loggedUser(user.user.id)
+    return { updatedEvent, updateUser }
   }
 
   async updateEvent(id: string, updateEventData: UpdateEventDto) {

--- a/back/src/mailer/dto/user-joinin-event.dtos.ts
+++ b/back/src/mailer/dto/user-joinin-event.dtos.ts
@@ -1,0 +1,23 @@
+import { IsDate, IsEmail, IsNotEmpty, IsString } from "class-validator";
+
+export class UserJoininEventDto {
+    @IsNotEmpty()
+    @IsString()
+    name: string;
+
+    @IsNotEmpty()
+    @IsEmail()
+    email: string;
+
+    @IsNotEmpty()
+    @IsString()
+    title: string;
+
+    @IsNotEmpty()
+    @IsDate()
+    eventDate: Date;
+
+    @IsNotEmpty()
+    @IsString()
+    eventLocation: string;
+}

--- a/back/src/seeder/seeder.module.ts
+++ b/back/src/seeder/seeder.module.ts
@@ -10,6 +10,7 @@ import { UserInformationService } from 'src/user-information/user-information.se
 import { EventsService } from 'src/events/events.service';
 import { EventsRepository } from 'src/events/events.repository';
 import { MailerService } from 'src/mailer/mailer.service';
+import { EventAssistantsRepository } from 'src/events/event-assistants.repository';
 
 @Module({
   controllers: [SeederController],
@@ -23,6 +24,7 @@ import { MailerService } from 'src/mailer/mailer.service';
     UserInformationService,
     EventsService,
     EventsRepository,
+    EventAssistantsRepository,
     MailerService,
   ],
   exports: [SeederService],

--- a/back/src/seeder/seeders/event.seed.ts
+++ b/back/src/seeder/seeders/event.seed.ts
@@ -6,7 +6,7 @@ const eventSeeder = [
     eventDate: '2024-12-24',
     eventLocation: 'Teatro Central',
     price: 1500,
-    stock: 50,
+    stock: 0,
     images: [
       'https://img.freepik.com/foto-gratis/gente-tiro-medio-cantando-juntos_23-2149535685.jpg?t=st=1727361921~exp=1727365521~hmac=63e2f1c5913d923ed75f503c4a3b99d96658e748a882a1ce0e9763fbad7402c3&w=1380',
     ],

--- a/back/src/user-information/entities/user-information.entity.ts
+++ b/back/src/user-information/entities/user-information.entity.ts
@@ -59,8 +59,4 @@ export class UserInformation {
 
   @OneToMany(() => EventAssistants, (eventAssistants) => eventAssistants.user)
   assistantEvents: EventAssistants[];
-
-  // @ManyToMany(() => Event, (event) => event.assistants)
-  // @JoinTable()
-  // assistantEvents: Event[];
 }

--- a/back/src/user-information/user-information.repository.ts
+++ b/back/src/user-information/user-information.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { UserInformation } from './entities/user-information.entity';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { User } from 'src/users/entities/user.entity';
+import { status } from 'src/common/enum/status.enum';
 
 @Injectable()
 export class UserInformationRepository extends Repository<UserInformation> {
@@ -21,10 +22,11 @@ export class UserInformationRepository extends Repository<UserInformation> {
   async loggedUser(params) {
     const loggedUser = await this.findOne({
       where: { user: { id: params } },
-      relations: { user: true, donations: true, events: true },
+      relations: { user: true, donations: true, events: true, assistantEvents: true }
     });
-    const { id, user, donations, events } = loggedUser;
-    return { creatorId: id, ...user, donations, events };
+    const { id, user, donations, events, assistantEvents } = loggedUser;
+    const assistantsConfirmet = assistantEvents.filter((assistant) => assistant.status === status.ACTIVE)
+    return { creatorId: id, ...user, donations, events, assistantEvents: assistantsConfirmet};
   }
 
   async findOneUser(id) {


### PR DESCRIPTION
Adds a new POST route `updateattendance/:id` that manages user attendance for events. The logic includes:

- If the user is not registered in the `event_assistants` table, a new record is created with the status set to `active`.
- If the user is already registered with the status `active`, it is changed to `inactive`, and if it is `inactive`, it is switched back to `active`.
- The route counts the number of active attendees and compares it with the event's stock to ensure capacity is not exceeded. For events without a capacity limit, this check is bypassed.

These changes ensure proper attendance tracking while handling event capacity dynamically.
